### PR TITLE
Fix rust-bindgen ident issue

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ version       ="1.0.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [build-dependencies]
-bindgen = "~0.62.0"
+bindgen = "~0.68.0"
 copy_dir = "~0.1.2"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ version       ="1.0.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [build-dependencies]
-bindgen = "~0.55.1"
+bindgen = "~0.62.0"
 copy_dir = "~0.1.2"
 
 [dependencies]

--- a/build.rs
+++ b/build.rs
@@ -60,10 +60,10 @@ fn main() {
             )
         })
         // export only these whitelisted types/functions
-        .whitelist_function("btor2parser_.*")
-        .whitelist_type("Btor2.*")
-        .whitelist_function("fopen")
-        .whitelist_function("fclose")
+        .allowlist_function("btor2parser_.*")
+        .allowlist_type("Btor2.*")
+        .allowlist_function("fopen")
+        .allowlist_function("fclose")
         // Tell cargo to invalidate the built crate whenever any of the
         // included header files changed.
         .parse_callbacks(Box::new(bindgen::CargoCallbacks))


### PR DESCRIPTION
Currently the `btor2tools` does not build. It panics with the following error 
```
thread 'main' panicked at '"Btor2Sort_union_(anonymous_at_/.../target/debug/build/btor2tools-sys-54a31d899707ee43/out/btor2tools-src/src/btor2parser/btor2parser_h_139_3)" is not a valid Ident', .../.cargo/registry/src/index.crates.io-6f17d22bba15001f/proc-macro2-1.0.69/src/fallback.rs:817:9
```

The issue is outlined here. It is resolved in later versions, specifically `>=0.62.0` 

- https://github.com/rust-lang/rust-bindgen/issues/2312

There are many other instances (such as [this](https://github.com/signalapp/boring/issues/18)) of fixes with just bumping the build dependency 